### PR TITLE
fix Inotify hot update bug

### DIFF
--- a/src/Process/Inotify.php
+++ b/src/Process/Inotify.php
@@ -68,7 +68,7 @@ class Inotify extends ProcessBase
             $monitorFiles[$wd] = $file;
         }
 
-        swoole_event_add($this->inotifyFd, function ($inotifyFd) use ($monitorFiles) {
+        swoole_event_add($this->inotifyFd, function ($inotifyFd) use (&$monitorFiles) {
             $events = inotify_read($inotifyFd);
             if ($events) {
                 foreach ($events as $ev) {


### PR DESCRIPTION
使用use没有对变量引用，导致设置监控集合失败