### PR TITLE
add table and column quote support, see #94

### DIFF
--- a/src/Pools/Miner.php
+++ b/src/Pools/Miner.php
@@ -290,11 +290,6 @@ class Miner
     private $intoValues;
 
     /**
-     * @var bool 是否启用debug模式,启用之后会在getStatement中输出创建好的SQL.
-     */
-    private $debugMode = false;
-
-    /**
      * Miner constructor.
      * @param $mysqlPool
      */
@@ -421,16 +416,6 @@ class Miner
             );
         }
 
-        return $this;
-    }
-
-    /**
-     * @param bool $debug 是否启用调试.
-     *
-     * @return $this
-     */
-    public function setDebug($debug = false) {
-        $this->debugMode = $debug;
         return $this;
     }
 
@@ -949,9 +934,6 @@ class Miner
             $statement = $this->getUpdateStatement($usePlaceholders);
         } elseif ($this->isDelete()) {
             $statement = $this->getDeleteStatement($usePlaceholders);
-        }
-        if ($this->debugMode) {
-            echo $statement . PHP_EOL;
         }
         return $statement;
     }


### PR DESCRIPTION
支持表名/字段名的转义,防止SQL错误:
```sql
$miner = new Miner();
$sql = (string)$miner->select('*')
    ->from('shows', 'group')
    ->innerJoin('episodes', 'show_id')
    ->where('shows.network_id', 12)
    ->orderBy('episodes.aired_on', Miner::ORDER_BY_DESC)
    ->limit(20)->getStatement(false);
echo $sql;
// SELECT * FROM `shows` AS `group` INNER JOIN `episodes` ON `shows`.`show_id` = `episodes`.`show_id` WHERE `shows`.`network_id` = '12' ORDER BY `episodes`.`aired_on` DESC LIMIT 20
```

