### PR TITLE
通过配置自定义Input类和Output类

### DIFF
--- a/src/Helpers/Context.php
+++ b/src/Helpers/Context.php
@@ -9,7 +9,6 @@
 namespace PG\MSF\Helpers;
 
 use PG\Context\AbstractContext;
-use PG\Log\PGLog;
 use PG\MSF\Base\Input;
 use PG\MSF\Base\Output;
 use PG\MSF\Base\Pool;

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -111,7 +111,13 @@ abstract class HttpServer extends Server
         $this->httpSocketName = $this->config['http_server']['socket'];
         $this->httpPort       = $this->config['http_server']['port'];
         $this->input          = $this->config->get('http.input', Input::class);
+        if (is_array($this->input)) {
+            $this->input = $this->input['class'] ?? Input::class;
+        }
         $this->output         = $this->config->get('http.output', Output::class);
+        if (is_array($this->output)) {
+            $this->output = $this->output['class'] ?? Output::class;
+        }
         return $this;
     }
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -47,6 +47,34 @@ abstract class HttpServer extends Server
      * @var array
      */
     public $viewResolvePaths;
+    
+    /**
+     * Input类
+     * 通过继承 PG\MSF\Base\Input 来自定义，默认是 PG\MSF\Base\Input
+     * 可以在配置文件中修改，例如：
+     * 
+     * ```php
+     * 'http' => [
+     *     'input' => PG\MSF\Base\Input::class,
+     * ]
+     * ```
+     * @var Input
+     */
+    public $input;
+    
+    /**
+     * Output类
+     * 通过继承 PG\MSF\Base\Output 来自定义，默认是 PG\MSF\Base\Output
+     * 可以在配置文件中修改，例如：
+     * 
+     * ```php
+     * 'http' => [
+     *     'output' => PG\MSF\Base\Output::class,
+     * ]
+     * ```
+     * @var Output
+     */
+    public $output;
 
     /**
      * HttpServer constructor.
@@ -82,6 +110,8 @@ abstract class HttpServer extends Server
         $this->httpEnable     = $this->config->get('http_server.enable', true);
         $this->httpSocketName = $this->config['http_server']['socket'];
         $this->httpPort       = $this->config['http_server']['port'];
+        $this->input          = $this->config->get('http.input', Input::class);
+        $this->output         = $this->config->get('http.output', Output::class);
         return $this;
     }
 
@@ -231,12 +261,12 @@ abstract class HttpServer extends Server
                 /**
                  * @var $input Input
                  */
-                $input    = $instance->context->getObjectPool()->get(Input::class);
+                $input    = $instance->context->getObjectPool()->get($this->input);
                 $input->set($request);
                 /**
                  * @var $output Output
                  */
-                $output   = $instance->context->getObjectPool()->get(Output::class, [$instance]);
+                $output   = $instance->context->getObjectPool()->get($this->output, [$instance]);
                 $output->set($request, $response);
 
                 $instance->context->setInput($input);

--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -8,8 +8,6 @@
 
 namespace PG\MSF\Rest;
 
-use PG\MSF\Base\Output;
-
 /**
  * Class Controller
  * @package PG\MSF\Rest
@@ -137,7 +135,7 @@ class Controller extends \PG\MSF\Controllers\Controller
      */
     public function outputOptions(array $options)
     {
-        /* @var $output Output */
+        /* @var $output \PG\MSF\Base\Output */
         $output = $this->getContext()->getOutput();
         $status = 200;
         if ($this->verb !== 'OPTIONS') {


### PR DESCRIPTION
通过继承 PG\MSF\Base\Input 和 PG\MSF\Base\Output 来自定义，然后在配置文件中增加
'http' => [
    'input' => PG\MSF\Base\Input::class,
    'output' => PG\MSF\Base\Output::class,
]